### PR TITLE
Fix redirect URI logic and router history for deployment

### DIFF
--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -11,7 +11,7 @@ const routes = [
 ];
 
 const router = createRouter({
-  history: createWebHistory(),
+  history: createWebHistory("/Spotify2YTmusic/"),
   routes,
 });
 

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,7 +1,9 @@
 const SPOTIFY_CLIENT_ID = import.meta.env.VITE_SPOTIFY_CLIENT_ID;
 const YOUTUBE_MUSIC_CLIENT_ID = import.meta.env.VITE_YOUTUBE_MUSIC_CLIENT_ID;
 const REDIRECT_URI =
-  import.meta.env.VITE_REDIRECT_URI || "http://localhost:5173/callback";
+import.meta.env.MODE === "development"
+  ? import.meta.env.VITE_REDIRECT_URI
+  : import.meta.env.VITE_DEPLOY_REDIRECT_URI;
 
 const generateRandomString = (length: number) => {
   const possible =

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -4,6 +4,7 @@ interface ImportMetaEnv {
   readonly VITE_SPOTIFY_CLIENT_ID: string;
   readonly VITE_YOUTUBE_MUSIC_CLIENT_ID: string;
   readonly VITE_REDIRECT_URI: string;
+  readonly VITE_DEPLOY_REDIRECT_URI: string;
   // more env variables...
 }
 


### PR DESCRIPTION
Update the REDIRECT_URI logic to use the deployment redirect URI and adjust the router history to include the base path for proper routing in the deployment environment.