### PR TITLE
Fix Spotify API helper logic

### DIFF
--- a/src/platform/spotify.ts
+++ b/src/platform/spotify.ts
@@ -23,8 +23,10 @@ export class SpotifySourcePlatform implements SourcePlatform {
         Authorization: `Bearer ${this.accessToken}`,
       },
     });
-    if (!response.ok) alert("Spotify API error: " + response.statusText);
-    throw new Error(`Spotify API error: ${response.statusText}`);
+    if (!response.ok) {
+      alert("Spotify API error: " + response.statusText);
+      throw new Error(`Spotify API error: ${response.statusText}`);
+    }
     return response.json();
   }
 
@@ -238,7 +240,6 @@ export class SpotifyTargetPlatform implements TargetPlatform {
       throw new Error(`Failed to follow artist: ${response.statusText}`);
     }
     return artist.id;
-    return "artist_id";
   }
 
   async findSong(song: Song): Promise<Song | null> {


### PR DESCRIPTION
## Summary
- fix early throw in Spotify API helper
- remove unreachable return in `addArtist`

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e79752388323b9c895a0db502e57